### PR TITLE
Changed makefile; added compilation output to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ rog_loogo_small.xcf
 roggui
 rog_gui.glade~
 rog_logo_icon.xcf
+gmon.out

--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ all:
 	@rm resource.cpp
 	@echo Done
 	@echo -n Compiling...
-	@${CXX} -o roggui ${CFLAGS} ${LIBS} main.cpp src/*.cpp
+	@${CXX} -p main.cpp src/*.cpp -o roggui ${CFLAGS} ${LIBS}
 	@echo Done
 install:
 	cp roggui /usr/local/bin	


### PR DESCRIPTION
Solving the following error:

`main.cpp:(.text+0x41): undefined reference to 'Glib::ustring::ustring(char const*)'`

`make: *** [makefile:12: all] Error 1`

Getting this error because gtkmm is statically linked and the libraries need to be at the end. If I add a `-p` flag, and make `main.cpp` & `src/*.cpp` swap places with `${CFLAGS}` & `${LIBS}`, it compiles properly.